### PR TITLE
allow multiple workIdentifiers

### DIFF
--- a/src/Product/RelatedWork.php
+++ b/src/Product/RelatedWork.php
@@ -15,11 +15,11 @@ class RelatedWork
     protected $WorkRelationCode;
 
     /**
-     * WorkIdentifier
+     * Array of WorkIdentifiers
      *
-     * @var WorkIdentifier
+     * @var arrayWorkIdentifier
      */
-    protected $WorkIdentifier;
+    protected $WorkIdentifier = [];
 
     /**
      * Set WorkRelationCode
@@ -33,14 +33,14 @@ class RelatedWork
     }
 
     /**
-     * Set WorkIdentifier
+     * Add a new WorkIdentifier
      *
      * @param WorkIdentifier $WorkIdentifier
      * @return void
      */
-    public function setWorkIdentifier(WorkIdentifier $WorkIdentifier)
+    public function addWorkIdentifier(WorkIdentifier $WorkIdentifier)
     {
-        $this->WorkIdentifier = $WorkIdentifier;
+        $this->WorkIdentifier[] = $WorkIdentifier;
     }
 
     /**
@@ -56,11 +56,21 @@ class RelatedWork
     /**
      * WorkIdentifier
      *
-     * @return WorkIdentifier
+     * @return array
      */
     public function getWorkIdentifier()
     {
         return $this->WorkIdentifier;
+    }
+
+     /**
+     * Remove WorkIdentifier
+     *
+     * @param WorkIdentifier $WorkIdentifier
+     * @return void
+     */
+    public function removeWorkIdentifier(WorkIdentifier $WorkIdentifier)
+    {
     }
 
 }


### PR DESCRIPTION
Allows processing of multiple values for WorkIdentifier in the case where multiple are found within the RelatedWork property

```
<relatedwork>
    <x454>01</x454>
    <workidentifier>
     <b201>01</b201>
     <b233>www.stisonbooks.com Content Identifier</b233>
     <b244>PLUTO-61647</b244>
    </workidentifier>
    <workidentifier>
     <b201>01</b201>
     <b233>www.stisonbooks.com Work Identifier</b233>
     <b244>PLUTO-62b857cf8c406</b244>
    </workidentifier>
   </relatedwork>
```